### PR TITLE
List RFC3550 as a normative reference

### DIFF
--- a/draft-uberti-avtcore-cryptex.md
+++ b/draft-uberti-avtcore-cryptex.md
@@ -30,6 +30,7 @@ author:
 
 normative:
   RFC2119:
+  RFC3350:
   RFC3711:
   RFC4566:
   RFC8285:

--- a/draft-uberti-avtcore-cryptex.md
+++ b/draft-uberti-avtcore-cryptex.md
@@ -30,7 +30,7 @@ author:
 
 normative:
   RFC2119:
-  RFC3350:
+  RFC3550:
   RFC3711:
   RFC4566:
   RFC8285:


### PR DESCRIPTION
A recent PR added a ref to RFC 3550, so it needs to be listed as a normative reference.