### PR TITLE
Remove IANA  considerations for defined by profile values

### DIFF
--- a/draft-ietf-avtcore-cryptex.md
+++ b/draft-ietf-avtcore-cryptex.md
@@ -342,8 +342,6 @@ such as DTLS is preferred (with its attendant per-packet overhead).
 IANA Considerations
 ===================
 
-This document defines two new 'defined by profile' attributes, as noted in RTP Header Processing.
-
 Acknowledgements
 ================
 


### PR DESCRIPTION
There is no IANA registry for RTP "defined by profile" values.

closes #33