### PR TITLE
Update IANA registration usage level

### DIFF
--- a/draft-ietf-avtcore-cryptex.md
+++ b/draft-ietf-avtcore-cryptex.md
@@ -397,7 +397,7 @@ Attribute semantics: N/A
     
 Attribute value: N/A
     
-Usage level: media-level
+Usage level: session, media
     
 Charset dependent: No
     


### PR DESCRIPTION
I think that changing session, media to media only was a mistake introduced by https://github.com/juberti/cryptex/commit/c91e2d29206692709783e2744e57fd6046ba0c42

This should fix #60